### PR TITLE
Use packrat with appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ tests/testthat/testdata/test_output*
 *.swp
 
 inst/GVA_by_sector.Rds
+eesectors.Rcheck

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,15 +6,18 @@ init:
         $ErrorActionPreference = "Stop"
         Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
-
 install:
   ps: Bootstrap
 
 # Adapt as necessary starting from here
 
+environment:
+  global:
+   WARNINGS_ARE_ERRORS: 0
+   USE_RTOOLS: true
+
 build_script:
-  - rm *.Rproj
-  - travis-tool.sh install_deps
+  - R -e  "0" --args --bootstrap-packrat
 
 test_script:
   - travis-tool.sh run_tests
@@ -41,3 +44,4 @@ artifacts:
 
   - path: '\*_*.zip'
     name: Bits
+


### PR DESCRIPTION
Tests on appveyor are failing due to version mismatches. This PR forces appveyor to use the packrat library as used by travis, and in local development.