### PR TITLE
Enable caching of package library in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,14 @@ init:
 install:
   ps: Bootstrap
 
+cache:
+  - C:\RLibrary
+
 # Adapt as necessary starting from here
 
 environment:
   global:
-   WARNINGS_ARE_ERRORS: 0
+   WARNINGS_ARE_ERRORS: 1
    USE_RTOOLS: true
 
 build_script:


### PR DESCRIPTION
Every time a test is run appveyor is installing all the libraries provided by packrat from the packrat/src folder. This is very slow, and leading to a build time of >16 minutes!

Caching the library after install should speed this up.